### PR TITLE
Service clients polling for services should wait if `ROSMasterError` is returned

### DIFF
--- a/axros/src/axros/serviceclient.py
+++ b/axros/src/axros/serviceclient.py
@@ -139,7 +139,7 @@ class ServiceClient(Generic[S]):
         while True:
             try:
                 await self._node_handle.master_proxy.lookup_service(self._name)
-            except rosxmlrpc.XMLRPCException:
+            except (rosxmlrpc.XMLRPCException, rosxmlrpc.ROSMasterError):
                 await util.wall_sleep(0.1)  # XXX bad
                 continue
             else:


### PR DESCRIPTION
Service clients which receive a `ROSMasterError` exception when attempting to check if a service is alive should be instructed to keep waiting. Not sure what about ROS might have changed this behavior, or if maybe we just never encountered this before.